### PR TITLE
Making the RAPID API accessible via socket communication

### DIFF
--- a/other/abb/server.mod
+++ b/other/abb/server.mod
@@ -1,0 +1,326 @@
+MODULE server
+    !***********************************************************
+    !
+    ! Module:  server
+    !
+    ! Description:
+    !   This module allows remote computers to access the RAPID API via socket communication.
+    !
+    !       -	The ABB robot acts as a server, hence the remote computer has to be configured
+	!		  	as a client.
+    !
+    !       -	When a socket error occurs, the server will be restarted automatically.
+    !
+    !       -	Messages of the following form are expected:
+    !
+    !           <length of the original message in bytes><delimiter><original message>
+    !           or in short form: <l><d><m>
+    !
+    !           The <length of the original message in bytes> = <l> has to be provided as an integer
+    !           number, whereby the delimiter and the original message have to be of the following
+	!           form:
+    !
+    !               <delimiter> = <d> = \n = \0A
+    !               <original message> = <m> = array of size 10; max. 80 bytes
+    !                   ->	The first element represents the id number and therefore a specific case.
+	!						Each case can consist of several RAPID commands which will be
+	!						executed once the received message is fully interpretated.
+    !                      	For more details see the example below or the code (TEST -
+	!						CASE instruction).
+    !                   ->	The remaining nine elements can be used for data, e.g. coordinates.
+    !
+    !           Example in Python 3.6:
+    !
+    !               socket.send(b"21\n[0,1,2,3,4,5,6,7,8,9]")
+    !
+    !           , where
+    !               <length of the original message in bytes> = <l> = 21
+    !               <delimiter> = <d> = \n = \0A
+    !               <original message> = <m> = [0,1,2,3,4,5,6,7,8,9]
+    !                   ->	id = 0, which will close the current connection; see below (TEST -
+	!					CASE instruction).
+    !                   ->	The remaining entries (1-9) can be arbitrary in this case, since they
+	!					    are not needed to close the connection. But because an array of size 10
+	!					    is expected, they have to be filled out.
+    !
+    !       -   The sequence <l><d><m>, see above, is called command request.
+    !
+    !       -   A message can contain several command requests. Thereby no separation/delimiter is
+    !           needed. E.g. '<l><d><m><l><d><m>'.
+    !
+    !       - 	After a message is sent to and fulfilled by the ABB robot, the ABB robot sends an
+	!			answer to the client if respond = TRUE.
+    !           -> 	The message is in JSON format with the entries:
+    !
+    !                   {'id':<id number>,'ok':<bool>,'data': <array of variable size>}
+    !
+    !               , where
+    !
+    !                   <id number>:    If the received message does not contain any errors, this id
+	!									number equals the id number in the received message.
+	!									Otherwise it represents an error code (negative number).
+    !                   <ok>:	If equals 0, an error occurred during the operation, otherwise not.
+    !                   <array of variable size>:	Represents the data to send back to the client.
+	!												Can be of variable size; the content depends on
+	!												the executed case and therefore the id number in
+    !                                               the received message.
+    !
+    ! For more details visit: https://github.com/EricssonResearch/arms
+    !
+    ! Author: HK team 2018
+    !
+    ! Version: 0.7
+    !
+    !***********************************************************
+
+
+    !******************
+    !Global variables.
+    !******************
+    PERS string host := "127.0.0.1";
+    PERS num port := 5001;
+    VAR socketdev server_socket;
+    VAR socketdev client_socket;
+    PERS num one_byte := 1;
+    VAR bool ok;
+
+
+    !************
+    !Procedures.
+    !************
+    PROC ServerCreateAndConnect(string host, num port)
+        !Creates a server and listens for incoming connections.
+        !The first client which tries to connect will be accepted.
+        !
+        ! Args:
+        !   host: Represents either a hostname in internet domain notation or an IPv4 address.
+        !   port: Port number (integer).
+        !
+        ! Attributes:
+        !   client_ip: The address bound to the socket on the other end of the connection.
+
+        VAR string client_ip;
+
+        SocketCreate server_socket;
+        SocketBind server_socket, host, port;
+        TPWrite "SERVER: Created server at (host, port)=(" + host + ", " + ValToStr(port) + ").";
+        SocketListen server_socket;
+        TPWrite "SERVER: Listening for incoming connections.";
+        WHILE SocketGetStatus(client_socket) <> SOCKET_CONNECTED DO
+            SocketAccept server_socket, client_socket \ClientAddress:=client_ip \Time:=WAIT_MAX;
+            IF SocketGetStatus(client_socket) <> SOCKET_CONNECTED THEN
+                TPWrite "SERVER: Problem serving an incoming connection.";
+                TPWrite "SERVER: Try reconnecting.";
+            ENDIF
+            !Wait some time for the next reconnection.
+            WaitTime 0.5;
+        ENDWHILE
+        TPWrite "SERVER: Connected to client with IP: " + client_ip + ".";
+    ENDPROC
+
+    PROC main()
+        !This prodecure does the following:
+        !   1. Gives the command to create a server.
+        !   2. Handles the communication with the client.
+        !       -   If the received message is faulty or can not be addressed, an error code will
+        !           be send back to the client.
+        !       -   If the received message is of the expected form, the addressed case will be
+        !           executed.
+        !       -   If respond = TRUE, an answer/respond will be send to the client.
+        !   3. Includes error handling. In most cases the server will be restarted and the last
+        !      (faulty) command will be retried to execute once the connection is rebuilt.
+        !
+        ! Attributes:
+        !   --- Receiving a message from the remote computer. ---
+        !   recv_string: Stores the received string data.
+        !   length_string: Stores the length of the original message to receive as a string.
+        !   length: Stores the into a numeric value casted/converted variable 'length_string'.
+        !   recv_params{10}: Represents the original message to receive as an array.
+        !   id: The value with which the test value will be compared (TEST - CASE instruction).
+        !
+        !   --- Sending a message to the remote computer. ---
+        !   respond: If TRUE, a answer/respond message will be send, otherwise not.
+        !   send_length: The length of 'send_string' which has to be send beforehand.
+        !   send_string: The original message to send.
+        !   ok_string: Represents the boolean variable 'ok' as a string; 0 = FALSE, 1 = TRUE.
+        !   data_string: The data to send, separated by a comma.
+        !
+        !   --- Other. ---
+        !   joints_pose: Represents the current joint pose/coordinates.
+
+        VAR string recv_string;
+        VAR string length_string;
+        VAR num length;
+        VAR num recv_params{10};
+        VAR num id;
+
+        VAR bool respond;
+        VAR string send_length;
+        VAR string send_string;
+        VAR string ok_string;
+        VAR string data_string;
+
+        VAR jointtarget joints_pose;
+
+        !Create server.
+        ServerCreateAndConnect host, port;
+
+        !Main procedure.
+        WHILE TRUE DO
+            !Reset flow variables.
+            ok := TRUE;
+            recv_string := "";
+            length_string := "";
+            length := 0;
+            respond := TRUE;
+            data_string := "";
+
+            !----------------------------------------------------
+            !Receive data from the socket (client) in two steps.
+            !----------------------------------------------------
+
+            !1. step:   Get the length of the message.
+            WHILE recv_string <> "\0A" DO
+                length_string := length_string + recv_string;
+                SocketReceive client_socket \Str:=recv_string \ReadNoOfBytes:=one_byte \Time:=WAIT_MAX;
+                IF StrFind(recv_string,1,STR_DIGIT) <> 1 AND StrFind(recv_string,1,"\0A") <> 1 THEN
+                    recv_string := "";
+                    length_string := "";
+                ENDIF
+            ENDWHILE
+
+            !2. step:   Receive the original message with respect to step one.
+            !           The following error codes are introduced, ok = FALSE:
+            !               1) id = -2: The received length l of the original message exceeds the
+            !                           bounds 0 < l <= 80.
+            !                           OR: The length could not be read/ casted into a number.
+            !               2) id = -3: The received original message could not be casted into an
+            !                           array.
+            !               3) id = -4: The received length is greater than the actual length of the
+            !                           original message.
+            !               4) id = -5: The received id number is below zero, which is not allowed
+            !                           since the id numbers < 0 are reserved for error codes.
+            !           Note that the first matching error code will be assigned to id.
+            ok:= StrToVal(length_string, length);
+            IF ok = TRUE AND length > 0 AND length <= 80 THEN
+                SocketReceive client_socket \Str:=recv_string \ReadNoOfBytes:=length \Time:=WAIT_MAX;
+                ok := StrToVal(recv_string, recv_params);
+                IF ok = TRUE THEN
+                    IF StrLen(recv_string) = length THEN
+                        id := recv_params{1};
+                        IF id < 0 THEN
+                            id := -5;
+                        ENDIF
+                    ELSE
+                        ok := FALSE;
+                        id := -4;
+                    ENDIF
+                ELSE
+                    id := -3;
+                ENDIF
+            ELSE
+                ok := FALSE;
+                id := -2;
+            ENDIF
+
+            !-----------------------------------------------------------------------------
+            !Find the case belonging to the id number and execute the respective commands.
+            !-----------------------------------------------------------------------------
+            TEST id
+                CASE 0: !Close connection.
+                    TPWrite "SERVER: The client has closed the connection.";
+
+                    !Close server.
+                    SocketClose client_socket;
+                    SocketClose server_socket;
+
+                    !Reinitiate server.
+                    ServerCreateAndConnect host, port;
+
+                    !Do not send a respond.
+                    respond := FALSE;
+
+                CASE 1: !Get system informations.
+                    TPWrite "SERVER: Send sytem information to client.";
+                    data_string := GetSysInfo(\SerialNo) + ", ";
+                    data_string := data_string + GetSysInfo(\SWVersion) + ", ";
+                    data_string := data_string + GetSysInfo(\RobotType);
+
+                CASE 10: !Get joint coordinates.
+                    TPWrite "SERVER: Send joint coordinates to client.";
+                    joints_pose := CJointT();
+                    data_string := NumToStr(joints_pose.robax.rax_1,2) + ", ";
+                    data_string := data_string + NumToStr(joints_pose.robax.rax_2,2) + ", ";
+                    data_string := data_string + NumToStr(joints_pose.robax.rax_3,2) + ", ";
+                    data_string := data_string + NumToStr(joints_pose.robax.rax_4,2) + ", ";
+                    data_string := data_string + NumToStr(joints_pose.robax.rax_5,2) + ", ";
+                    data_string := data_string + NumToStr(joints_pose.robax.rax_6,2);
+
+                DEFAULT:
+                    TPWrite "SERVER: Illegal (not addressed) id number: " + ValToStr(id) + ".";
+                    !The error codes have to be kept, otherwise set id = -1 to indicate that there
+                    !is currently not a case belonging to the received id number.
+                    IF id >= 0 THEN
+                        id := -1;
+                    ENDIF
+                    !Error occurred.
+                    ok := FALSE;
+            ENDTEST
+
+            !---------------------------------------------------
+            !Send an answer in JSON format back to the client.
+            !---------------------------------------------------
+            IF respond = TRUE AND SocketGetStatus(client_socket) = SOCKET_CONNECTED THEN
+                !Convert the bool variable 'ok' to a string; 1 = TRUE, 0 = FALSE.
+                ok_string := "0";
+                IF ok = TRUE THEN
+                    ok_string := "1";
+                ENDIF
+
+                !Translate the message to send into JSON format.
+                send_string := "{'id':" + NumToStr(id, 0) + ",";
+                send_string := send_string + "'ok':" + ok_string + ",";
+                send_string := send_string + "'data': '[" + data_string + "]'}";
+
+                !+++++++++++++++++++++++++++++++++++++++++++++++
+                !Send data to the socket (client) in two steps.
+                !+++++++++++++++++++++++++++++++++++++++++++++++
+
+                !1. step:   Send the length of the message.
+                send_length := NumToStr(StrLen(send_string), 0) + "\0A";
+                SocketSend client_socket \Str:=send_length;
+
+                !2. step:   Send the original message.
+                SocketSend client_socket \Str:=send_string;
+		    ENDIF
+        ENDWHILE
+
+    ERROR (LONG_JMP_ALL_ERR)
+        TPWrite "SERVER: Error Handler - " + NumtoStr(ERRNO,0) + ".";
+        TEST ERRNO
+            CASE ERR_SOCK_CLOSED:
+                TPWrite "SERVER: Lost connection to the client.";
+                TPWrite "SERVER: The socket will be closed and restarted.";
+                !Close server.
+                SocketClose client_socket;
+                SocketClose server_socket;
+                !Reinitiate server.
+                ServerCreateAndConnect host, port;
+                !Retry last command.
+                RETRY;
+            CASE ERR_OUTOFBND:
+                !The array index is outside the permitted limits.
+                ok := FALSE;
+            DEFAULT:
+                TPWrite "SERVER: Unknown error.";
+                TPWrite "SERVER: The socket will be closed and restarted.";
+                !Close server.
+                SocketClose client_socket;
+                SocketClose server_socket;
+                !Reinitiate server.
+                ServerCreateAndConnect host, port;
+                !Retry last command.
+                RETRY;
+        ENDTEST
+    ENDPROC
+ENDMODULE

--- a/other/abb/tests/test_server.py
+++ b/other/abb/tests/test_server.py
@@ -1,0 +1,253 @@
+"""Tests for the module server.mod running on an ABB robot/controller.
+
+Quick Setup/ Run tests:
+    - Start ABB RobotStudio.
+    - Create an empty station (File -> New -> Empty station).
+    - Place a robot (Home -> Tab 'Build Station' -> ABB Library -> Select a
+      robot and press Ok).
+    - Create a system based on an existing layout (Home -> Tab 'Build Station'
+      -> Robot System -> From Layout... -> Next -> Next -> Finish).
+    - Check PC Interface (Controller -> Tab 'Virtual Controller' -> Change
+      Options -> Communication -> Check '616-1 PC Interface' -> Ok -> Yes).
+    - Create a new RAPID module and name it 'server' (Left panel -> RAPID ->
+      Right click on T_ROB1 -> New module... -> Module name: server -> Ok).
+    - Copy and Paste the code from server.mod in the just created module.
+    - Start the execution (RAPID -> Tab 'Test and Debug' -> Press Start).
+    - Open the command window. The tests can be run with:
+        $ cd */project folder/arms/other/abb
+        $ pytest
+"""
+
+import json
+import pytest
+import socket
+import time
+
+
+def recv(s):
+    """Receives data from the socket in two steps.
+        1. step: Get the length of the message.
+        2. step: Receive the original message with respect to step one.
+
+    Args:
+        s: The socket.
+
+    Return:
+        [id, ok], where
+        id: If the given message to the ABB robot does not contain any errors,
+            this id number is the same as in the given message. Otherwise it
+            represents an error code (negative number).
+        ok: If False, an error occurred during the operation of the ABB robot,
+            otherwise not.
+    """
+    # 1. step: Read the length of the data.
+    length_str = ""
+    char = ""
+    while char != '\n':
+        length_str += char
+        char = s.recv(1).decode()
+        if (char.isdigit() is False) and (char != "") and (char != '\n'):
+            char = ""
+
+    total = int(length_str)
+
+    # 2. step: Receive the data chunk by chunk.
+    view = memoryview(bytearray(total))
+    next_offset = 0
+    while total - next_offset > 0:
+        recv_size = s.recv_into(view[next_offset:], total - next_offset)
+        next_offset += recv_size
+
+    data = view.tobytes().decode()
+    data = data.replace("'", '\"')
+    data = json.loads(data)
+
+    return [data['id'], bool(data['ok'])]
+
+
+@pytest.fixture(scope="class")
+def server():
+    """Connects with the ABB robot and closes the socket once all tests are
+    completed in the respective class.
+    """
+    # Setup: connect to socket.
+    host = "127.0.0.1"
+    port = 5001
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((host, port))
+    s.settimeout(20)
+
+    yield s
+
+    # Teardown: close socket.
+    msg = b"21\n[0,0,0,0,0,0,0,0,0,0]"
+    s.send(msg)
+    s.close()
+
+
+class TestExchangeOfMessages:
+
+    """Contains all tests regarding the exchange (sending and
+    receiving) of messages between the ABB robot and the client.
+    """
+
+    @pytest.mark.parametrize("msg, no, expected", [
+        (b"21\n[1,0,0,0,0,0,0,0,0,0]", 1, [[1, True]]),
+        (b"21\n[1,0,0,0,0,0,0,0,0,0]21\n[1,0,0,0,0,0,0,0,0,0]", 2,
+         [[1, True], [1, True]]),
+    ])
+    def test_correct(self, server, msg, no, expected):
+        """WHEN a message of expected form is given to the ABB robot,
+        THEN the ABB robot shall respond with ok = True and the returned id
+        number shall equal the given id number.
+        """
+        server.send(msg)
+        for idx in range(no):
+            received = recv(server)
+            assert received == expected[idx]
+
+
+    @pytest.mark.parametrize("msg, no, expected", [
+        (b"24\n[1000,0,0,0,0,0,0,0,0,0]", 1, [[-1, False]]),
+        (b"24\n[1000,0,0,0,0,0,0,0,0,0]24\n[1000,0,0,0,0,0,0,0,0,0]", 2,
+         [[-1, False], [-1, False]]),
+    ])
+    def test_no_respective_case(self, server, msg, no, expected):
+        """IF there is no case belonging to an id number, THEN the ABB robot
+        shall respond with id = -1 and ok = False.
+        """
+        server.send(msg)
+        for idx in range(no):
+            received = recv(server)
+            assert received == expected[idx]
+
+
+    @pytest.mark.parametrize("msg, expected", [
+        (b"0\n", [-2, False]),
+        (b"81\n", [-2, False]),
+        (b"\n", [-2, False]),
+        (b"\n[0,1,2,3,4,5,6,7,8,9]", [-2, False]),
+        (b"a\n[0,1,2,3,4,5,6,7,8,9]", [-2, False]),
+    ])
+    def test_wrong_length(self, server, msg, expected):
+        """IF the given length l of the original message exceeds the
+        bounds 0 < l <= 80, or the given length can not be read/ casted
+        into a number, THEN the ABB robot shall respond with id = -2 and ok
+        = False.
+        """
+        server.send(msg)
+        received = recv(server)
+        assert received == expected
+
+
+    @pytest.mark.parametrize("msg, expected", [
+        (b"7\n[1,0,0]", [-3, False]),
+        (b"10\n[1,0,0]", [-3, False]),
+        (b"30\n[0,1,2,3,4,5,6,7,8,9,10,11,12]", [-3, False]),
+        (b"1\n[0,1,2,3,4,5,6,7,8,9]", [-3, False]),
+        (b"20\n[0,1,2,3,4,5,6,7,8,9]", [-3, False]),
+        (b"3\nabc", [-3, False]),
+        (b"3\n123", [-3, False]),
+        (b"10\n[1,0,0]21\n[1,0,0,0,0,0,0,0,0,0]", [-3, False]),
+    ])
+    def test_wrong_array(self, server, msg, expected):
+        """IF the given original message can not be casted into an array,
+        and the error code {-2} does not apply, THEN the ABB robot shall
+        respond with id = -3 and ok = False.
+        Note: Reasons that this error code gets raised include:
+            - The array size in the given original message differs from 10.
+            - The given length of the original message is too small and hence
+              the original message is not read completely by the ABB robot.
+            - The given original message does not contain an array.
+            - The message contains several command requests, but the given
+              length of the first one is greater than the actual length of
+              the original message.
+        """
+        server.send(msg)
+        received = recv(server)
+        assert received == expected
+
+
+    @pytest.mark.parametrize("msg, expected", [
+        (b"30\n[0,1,2,3,4,5,6,7,8,9]", [-4, False]),
+    ])
+    def test_discrepancy_length(self, server, msg, expected):
+        """IF the given length is greater than the actual length of the
+        original message, and the error codes {-2, -3} do not apply, THEN
+        the ABB robot shall respond with id = -4 and ok = False.
+        """
+        server.send(msg)
+        received = recv(server)
+        assert received == expected
+
+
+    @pytest.mark.parametrize("msg, no, expected", [
+        (b"22\n[-1,0,0,0,0,0,0,0,0,0]", 1, [[-5, False]]),
+        (b"22\n[-2,0,0,0,0,0,0,0,0,0]", 1, [[-5, False]]),
+        (b"22\n[-3,0,0,0,0,0,0,0,0,0]", 1, [[-5, False]]),
+        (b"22\n[-4,0,0,0,0,0,0,0,0,0]", 1, [[-5, False]]),
+        (b"22\n[-5,0,0,0,0,0,0,0,0,0]", 1, [[-5, False]]),
+    ])
+    def test_negative_id(self, server, msg, no, expected):
+        """IF the given id number is below zero, and the error codes {-2,
+        -3, -4} do not apply, THEN the ABB robot shall respond with id = -5
+        and ok = False.
+        Reason: id numbers below zero (<0) are reserved for error codes.
+        """
+        server.send(msg)
+        for idx in range(no):
+            received = recv(server)
+            assert received == expected[idx]
+
+
+    @pytest.mark.parametrize("msg, no, expected", [
+        (b"22\n[-1,0,0,0,0,0,0,0,0,0]22\n[-1,0,0,0,0,0,0,0,0,0]", 2,
+         [[-5, False], [-5, False]]),
+        (b"7\n[1,0,0]21\n[1,0,0,0,0,0,0,0,0,0]", 2, [[-3, False], [1, True]]),
+        (b"3\n[1,0,0]21\n[1,0,0,0,0,0,0,0,0,0]", 2, [[-3, False], [1, True]]),
+        (b"8\n[1,0,0]21\n[1,0,0,0,0,0,0,0,0,0]", 2, [[-3, False], [-3, False]]),
+        (b"21\n[1,0,0,0,0,0,0,0,0,0]7\n[1,0,0]", 2, [[1, True], [-3, False]]),
+    ])
+    def test_mix(self, server, msg, no, expected):
+        """IF the given message contains several command requests with correct
+        message length and delimiter, THEN all command requests shall be
+        processed correctly with respect to the error codes.
+        """
+        server.send(msg)
+        for idx in range(no):
+            received = recv(server)
+            assert received == expected[idx]
+
+
+    def test_no_delimiter(self, server):
+        """When the given message does not contain the expected delimiter '\n',
+        the ABB robot shall keep listening for new messages."""
+        # A message that does not contain the expected delimiter '\n'.
+        msg = b"21[1,0,0,0,0,0,0,0,0,0]"
+        server.send(msg)
+        server.settimeout(1)
+        with pytest.raises(socket.timeout):
+            recv(server)
+        server.settimeout(None)
+
+        # A new (correct) message.
+        msg = b"21\n[1,0,0,0,0,0,0,0,0,0]"
+        server.send(msg)
+        received = recv(server)
+        assert received == [1, True]
+
+
+def test_reconnect():
+    """IF the ABB robot looses the connection to the client, THEN the ABB
+    robot shall restart the server."""
+    host = "127.0.0.1"
+    port = 5001
+
+    for _ in range(2):
+        time.sleep(0.5)
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(2.0)
+        s.connect((host, port))
+        s.send(b"21\n[1,0,0,0,0,0,0,0,0,0]")
+        assert recv(s) == [1, True]
+        s.close()


### PR DESCRIPTION
Issue: #3.

Hereby the RAPID module _server_  is introduced, which allows remote computers to access the ABB RAPID API via socket communication.

---
**Background**
A similar work can be found here, [link](https://github.com/robotics/open_abb). The reason for refactoring [the code](https://github.com/robotics/open_abb/blob/fuerte-devel/RAPID/SERVER.mod) in that repository lays in the following observations:
- _Message protocol:_ Messages have to be of the following form: \<id>\<delimiter>\<data>\<delimiter>\<end sign>, where
  - \<id>: Used to address a specific case in the TEST-CASE instruction in RAPID.
  - \<delimiter>: Equals a space (' ').
  - \<data>: Optional parameter, values are separated with a space (' '), maximum of 8 values; is casted into an array of size 10 in RAPID. 
  - \<end sign>: Equals #.
- Because of the chosen message protocol a relative complicated parser is needed. 
- The id number must consist of two digits, e.g. {01, 10, 99}.
- Furthermore the message length to expect is not stated, which consequences in:
  - The argument \ReadNoOfBytes of SocketReceive in RAPID can not be used.
  - Let's say a command request is a message containing one id, then a message with two command requests would contain two id's, and so on. Then another consequence is that a  sequence of command requests is not allowed and would lead to an error. 
    - An example for this case would be when the client sends two command requests in a row, before the server (ABB robot/IRC5) has even started serving one of them.
- The message to send back does not contain only data.
---
**Proposal**
The enclosed proposal tries to improve these disadvantages and works as follows:
- The ABB robot is set up as a server, (host, port) = ("127.0.0.1", 5001).
- When a socket error occurs, the server will be restarted automatically.
- Message protocol: The ABB robot can handle messages of the form:
\<length of the original message in bytes>\<delimiter>\<original message> = \<l>\<d>\<m>, where:
  - \<length of the original message in bytes> = \<l> = integer
  - \<delimiter> = \<d> = \n
  - \<original message> = \<m> = array of size 10; max. 80 bytes
    - The first element represents the id number and therefore a specific case in RAPID.
    - The remaining nine elements can be used for data, e.g. coordinates.
  -  The sequence <l><d><m>, see above, is called command request.
  - A message can contain several command requests. Thereby no separation/delimiter is needed. E.g. \<l>\<d>\<m>\<l>\<d>\<m>.
  - After a message is sent to and fulfilled by the ABB robot, the ABB robot sends an answer to the client.
    - The message is of the same format as described above, \<l>\<d>\<m>.
    - The original message is in JSON format with the entries:
      {'id':\<id number>,'ok':\<bool>,'data': \<array of variable size>}, where
      - \<id number>: If the given message does not contain any errors, this received id number equals the id number in the given message. Otherwise it represents an error code (negative number, see below).
      - \<ok>: If equals 0, an error occurred during the operation of the ABB robot, otherwise not.
      - \<array of variable size>:	Represents the data which is returned by the ABB robot.
     - The message is send back in three steps so that the full 80 bytes  (limitation for strings in RAPID) can be used for data.

**Error codes:**

- id = -1: There is currently not a case specified in the RAPID code belonging to the given id number.
- id = -2: The given length l of the original message exceeds the bounds 0 < l <= 80. OR: The length could not be read/ casted into a number.
- id = -3: The given original message could not be casted into an array.
- id = -4: The given length is greater than the actual length of the original message.
- id = -5: The given id number is below zero, which is not allowed since the id numbers < 0 are reserved for error codes.
- id = -10: The data supposed to send back is too long (>80 bytes) and has to be reseted.

**Main differences to the code referred to in _Background_:**
- The given data in the original message has to be provided as an array and will be directly casted into an array in RAPID. A (complicated) parser therefore is not needed. This idea was developed on the observation that the code referred to above does the same thing in the parser procedure; and hence on the question: Why do not do it directly?
- The id number now can have any number of digits.
- A sequence of command requests is allowed.
- Error codes are introduced to give better feedback to the client. They can be used for example to define respective error handlers on the client side to achieve a more stable operation process.

---
**Tests**
Attached are some tests written in Python (pytest) as well. They proof the fulfillment of the following requirements:
- WHEN a message of expected form is given to the ABB robot, THEN the ABB robot shall respond with ok = True and the returned id number shall equal the given id number.
- IF there is no case belonging to an id number, THEN the ABB robot shall respond with id = -1 and ok = False.
- IF the given length l of the original message exceeds the bounds 0 < l <= 80, or the given length can not be read/ casted into a number, THEN the ABB robot shall respond with id = -2 and ok = False.
- IF the given original message can not be casted into an array, and the error code {-2} does not apply, THEN the ABB robot shall respond with id = -3 and ok = False.
- IF the given length is greater than the actual length of the original message, and the error codes {-2, -3} do not apply, THEN the ABB robot shall respond with id = -4 and ok = False.
- IF the given id number is below zero, and the error codes {-2, -3, -4} do not apply, THEN the ABB robot shall respond with id = -5 and ok = False.
- IF the given message contains several command requests with correct message length and delimiter, THEN all command requests shall be processed correctly with respect to the error codes.
- When the given message does not contain the expected delimiter '\n', the ABB robot shall keep listening for new messages.
- IF the ABB robot looses the connection to the client, THEN the ABB robot shall restart the server.

---
**Update 1**
Arian and me tested the code today on the "real" robot and it worked fine. Note that for testing on the "real" robot the host and port number have to be changed to the default address:
- host: "192.168.125.1"
- port: 5000

---
**Update 2**
- Now the response of the ABB is send back in three steps, so that the full 80 bytes (limitation for strings in RAPID) can be used for data.
- Some renaming and changing of comments were done.

Closes #3.