### PR TITLE
Add method ABB.connect

### DIFF
--- a/arms/units/abb.py
+++ b/arms/units/abb.py
@@ -23,6 +23,11 @@ class ABB:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.close()
 
+    def connect(self):
+        """Connects to the socket server."""
+        ok, connected = self.client.get_config_and_connect()
+        return ok, connected
+
     def close(self):
         """Close connection."""
         case = 0


### PR DESCRIPTION
Issue: #57.

Added a method to connect with the socket server. It returns two values [*1, *2]:
- *1: True, if a setting entry belonging to the client ('abb') could be found and no data type violation occurred. False, if not.
- *2: True, if a connection could be made. False, if not.

Closes: #57.


