### PR TITLE
Refactor of SocketClient.get_config_and_connect

### DIFF
--- a/arms/misc/socket.py
+++ b/arms/misc/socket.py
@@ -25,9 +25,10 @@ class SocketClient:
         server.
 
         Return:
-            - True, if a setting entry belonging to the client (client_name)
-            could be found and no data type violation occurred.
-            - False, if not.
+			- [#1, #2]
+				#1: True, if a setting entry belonging to the client (client_name)
+					could be found and no data type violation occurred. False, if not.
+				#2: True, if a connection could be made. False, if not.
         """
         try:
             c = config.var.data['socket'][self.name]
@@ -38,11 +39,11 @@ class SocketClient:
                              'socket {} in the configuration file ('
                              'arms/config/config.json). Hence, no '
                              'connection could be made.'.format(self.name))
-            return False
+            return [False, False]
 
         if isinstance(host, str) and isinstance(port, int):
             ok = self.connect(host, port)
-            return ok
+            return [True, ok]
         else:
             log.socket.error('Data type violation. The host number has to be '
                              'provided as a string and the port number as an '
@@ -50,7 +51,7 @@ class SocketClient:
                              'arms/config/config.json). In consequence, the '
                              'socket {} could not connect to the server.'
                              .format(self.name))
-            return False
+            return [False, False]
 
     def connect(self, host, port):
         """Establishes a connection to a server.

--- a/tests/unit/test_socket.py
+++ b/tests/unit/test_socket.py
@@ -39,11 +39,12 @@ def test_get_config_and_connect():
     """
     client = SocketClient("test_socket")
     data = {"socket": {"test_socket": {"host": host, "port": port}}}
-    client.connect = mock.MagicMock()
+    mock_connect = mock.MagicMock()
+    client.connect = mock_connect
 
     with mock.patch.object(config.var, 'data', data):
         client.get_config_and_connect()
-        client.connect.assert_called_with(host, port)
+        mock_connect.assert_called_with(host, port)
 
 
 config_none = None
@@ -65,16 +66,17 @@ def test_get_config_and_connect_fail(config_data):
     """WHEN the function 'get_config_and_connect' is called, IF the config
     entry containing the host name and port number to the specified client
     (client_name) is of the wrong format or does not exist, THEN no attempt
-    to connect with the respective server shall be made and the boolean value
-    False shall be returned.
+    to connect with the respective server shall be made and the boolean values
+    [False, False] shall be returned.
     """
     client = SocketClient("test_socket")
-    client.connect = mock.MagicMock()
+    mock_connect = mock.MagicMock()
+    client.connect = mock_connect
 
     with mock.patch.object(config.var, 'data', config_data):
         ok = client.get_config_and_connect()
-        client.connect.assert_not_called()
-        assert ok is False
+        mock_connect.assert_not_called()
+        assert ok == [False, False]
 
 
 def test_connect():
@@ -185,7 +187,7 @@ class SocketServer:
         """Closes the socket and the connection to the client."""
         if self.conn is not None:
             self.conn.close()
-            
+
         if self.sock is not None:
             self.sock.close()
 


### PR DESCRIPTION
Issue: #59.

Now the method SocketClient.get_config_and_connect returns [*1, *2]:
- *1: True, if a setting entry belonging to the client (client_name) could be found and no data type violation occurred. False, if not.
- *2: True, if a connection could be made. False, if not.

In addition, some tests were updated.

Closes #59.