### PR TITLE
Fetching and evaluating of DU failure reports

### DIFF
--- a/arms/units/alarms.py
+++ b/arms/units/alarms.py
@@ -1,0 +1,46 @@
+"""Utilities related to receiving and evaluating of DU failure reports."""
+
+import requests
+import time
+from arms.config import config
+from arms.utils import log
+
+
+class Alarms:
+
+    """Receiving and evaluating of DU failure reports."""
+
+    def listen(self):
+        """Connects with the web server 'alarms' specified in the settings
+        (arms/config/config.json -> web -> alarms) and waits for an error
+        message.
+
+        Return:
+            -   True, if a hardware link failure was reported.
+            -   False, if an internal error occurred.
+        """
+
+        try:
+            host = config.var.data['web']['alarms']['host']
+            port = config.var.data['web']['alarms']['port']
+            url = config.var.data['web']['alarms']['url']
+            webpage = host + ":" + str(port) + url
+            response = requests.get(webpage).text
+        except (TypeError, KeyError):
+            log.alarms.critical("Could not find (appropriate) settings in the "
+                                "configuration file (arms/config/config.json) "
+                                "to reach the website responsible for sending "
+                                "failure reports. Hence, this service will be "
+                                "closed.")
+            return False
+        except requests.exceptions.RequestException:
+            time.sleep(60)
+            return self.listen()
+
+        if response == "A":
+            log.alarms.info("The error code ({}) was received. The healing "
+                            "process will be started.".format(response))
+            return True
+        else:
+            time.sleep(60)
+            return self.listen()

--- a/arms/utils/log.py
+++ b/arms/utils/log.py
@@ -71,6 +71,7 @@ def get_logger(name):
 
 # The different loggers used (alphabetical order).
 abb = get_logger('abb')
+alarms = get_logger('alarms')
 app = get_logger('app')
 ard_log = get_logger('ard_log')
 camera = get_logger('camera')

--- a/other/alarms/alarmSample.txt
+++ b/other/alarms/alarmSample.txt
@@ -1,0 +1,7 @@
+===================================================================================================================================================================================================================
+Date & Time (Local) S Specific Problem                      				MO (Cause/AdditionalInfo)
+===================================================================================================================================================================================================================
+2018-11-22 15:52:19 M Gigabit Ethernet Link Fault         				Subrack=1,Slot=1,PlugInUnit=1,ExchangeTerminalIp=1,GigaBitEthernet=1 (Autonegotiation Failed to Meet Minimum Requirements.)
+2018-11-22 16:03:19 M Network Synch Time from GPS Missing 				Subrack=1,Slot=1,PlugInUnit=1,TimingUnit=1,GpsSyncRef=1 (Cause: Loss of signal)
+2018-11-23 10:23:52 m Link Failure RiLink=1 (No signal detected (link start time-out)   ManagedElement=1,Equipment=1,Subrack=1,Slot=1,PlugInUnit=1,RiPort=A (transportType=NOT_SET)
+

--- a/other/alarms/alservice_rest.py
+++ b/other/alarms/alservice_rest.py
@@ -1,0 +1,21 @@
+from flask import Flask
+import os
+import sys
+
+app = Flask(__name__)
+
+@app.route('/alarms')
+def alarms():
+
+	with open(os.getcwd() + '/alarmSample.txt', 'r') as f:
+		lines = f.readlines()
+		f.close()
+	for line in lines:
+		if "Link Failure" in line:
+			return line[line.find("RiPort") + 7:line.find("RiPort") + 8]
+
+	return "no alarm"
+
+
+if __name__ == '__main__':
+	app.run(host='0.0.0.0', port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # List of files to be installed using pip install.
+requests
 pytest

--- a/tests/unit/test_alarms.py
+++ b/tests/unit/test_alarms.py
@@ -1,0 +1,90 @@
+"""Tests for arms.units.alarms.Alarms.listen"""
+
+import pytest
+import requests
+from unittest import mock
+from arms.config import config
+from arms.units import alarms
+
+
+class DotDict(dict):
+    """Access the keys of a dictionary via a dot notation.
+
+    Example:
+        val = Map({'text': "No error"})
+        val.text -> "No error"
+    """
+    __getattr__ = dict.get
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+
+@mock.patch.object(alarms.requests, 'get', return_value=DotDict({'text': "A"}))
+def test_listen_alarm(mock_requests):
+    """WHILE the webpage information for 'alarms' could be found in the
+    settings (see details below), WHILE the requested server is online,
+    the method 'listen' shall fetch the information from the server and return
+    the boolean value True if the received error message equals the letter 'A'.
+
+    Note that the following config entry is needed:
+        arms.config.config.json -> web -> alarms -> host, port, url
+    """
+    alarm = alarms.Alarms()
+    config_data = {"web": {"alarms": {"host": "a", "port": "b", "url": "c"}}}
+    with mock.patch.object(config.var, 'data', config_data):
+        assert alarm.listen() is True
+        mock_requests.assert_called()
+
+
+@pytest.mark.parametrize("config_data", [
+    None,
+    {},
+    ({"color": "blue"}),
+    ({"web": {"color": "blue"}}),
+    ({"web": {"alarms": {"color": "blue"}}}),
+    ({"web": {"alarms": {"host": "a", "color": "b", "url": "c"}}}),
+])
+def test_listen_dict_error(config_data):
+    """IF no webpage information for 'alarms' could be found or if they are
+    incomplete, THEN the boolean value False shall be returned.
+    """
+    alarm = alarms.Alarms()
+    with mock.patch.object(config.var, 'data', config_data):
+        assert alarm.listen() is False
+
+
+@mock.patch.object(alarms.requests, 'get', return_value=None,
+                   side_effect=requests.exceptions.RequestException)
+@mock.patch('time.sleep', return_value=None)
+def test_listen_request_error(mock_time, mock_requests):
+    """IF the requested server is offline, WHILE the webpage information for
+    'alarms' are available, the system shall sleep for awhile and try to
+    fetch the information from the server again.
+    """
+    alarm = alarms.Alarms()
+    listen = alarm.listen
+    config_data = {"web": {"alarms": {"host": "a", "port": "b", "url": "c"}}}
+    with mock.patch.object(config.var, 'data', config_data):
+        with mock.patch.object(alarms.Alarms, 'listen', return_value="loop"):
+            assert listen() == "loop"
+            mock_requests.assert_called()
+            mock_time.assert_called()
+
+
+@mock.patch.object(alarms.requests, 'get',
+                   return_value=DotDict({'text': "No error"}))
+@mock.patch('time.sleep', return_value=None)
+def test_listen_no_alarm(mock_time, mock_requests):
+    """WHILE the webpage information for 'alarms' could be found in the
+    settings, WHILE the requested server is online, the method 'listen' shall
+    sleep awhile and make a request again if the fetched information does not
+    equal the letter 'A'.
+    """
+    alarm = alarms.Alarms()
+    listen = alarm.listen
+    config_data = {"web": {"alarms": {"host": "a", "port": "b", "url": "c"}}}
+    with mock.patch.object(config.var, 'data', config_data):
+        with mock.patch.object(alarms.Alarms, 'listen', return_value="loop"):
+            assert listen() == "loop"
+            mock_requests.assert_called()
+            mock_time.assert_called()


### PR DESCRIPTION
Issue: #62.

Adds:
- A small script that starts a server and provides the DU link failure.
- A python class that fetches the information from the server and returns:
   - True, if a hardware link failure with error code _A_ was reported.
   - False, if an internal error occurred. 

Tests show the fulfillment of the following requirements:
- WHILE the webpage information for 'alarms' could be found in the settings (see details below), WHILE the requested server is online, the method 'listen' shall fetch the information from the server and return the boolean value True if the received error message equals the letter 'A'.
   - Note that the following config entry is needed:
                    arms.config.config.json -> web -> alarms -> host, port, url
- IF no webpage information for 'alarms' could be found or if they are incomplete, THEN the boolean value False shall be returned.
- IF the requested server is offline, WHILE the webpage information for 'alarms' are available, the system shall sleep for awhile and try to fetch the information from the server again.
- WHILE the webpage information for 'alarms' could be found in the settings, WHILE the requested server is online, the method 'listen' shall sleep awhile and make a request again if the fetched information does not equal the letter 'A'.

Closes #62.